### PR TITLE
use let* for expand-env

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3428,7 +3428,7 @@ considered when expanding the snippet."
                (yas/inhibit-overlay-hooks
                  (setq snippet
                        (if expand-env
-                           (eval `(let ,expand-env
+                           (eval `(let* ,expand-env
                                     (insert content)
                                     (yas/snippet-create (point-min) (point-max))))
                          (insert content)


### PR DESCRIPTION
I couldn't find any discussions on this topic from a quick search, but is there any reason not to use `let*` instead of `let` for `expand-env`? By using `let*` one can have a snippet like so:

```
# -*- mode: snippet -*-
# name: testfile
# key: testfile
# expand-env: ((inputfile (file-name-nondirectory (buffer-file-name))) (outputfile (file-name-sans-extension inputfile)))
# --
// -*- compile-command: "g++ -g -o `outputfile` `inputfile`" -*-

int main(int argc, char *argv[])
{
    $0
    return 0;
}
```

I guess that `let*` might encourage huge values for `expand-env` (like in the above snippet), but I really like how clean it makes the snippet body...
