### PR TITLE
Fix the yas/compile-* mode detection

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -1719,7 +1719,7 @@ Prompts for INPUT-DIR and OUTPUT-FILE if called-interactively"
   (interactive (let* ((input-dir (read-directory-name "Snippet dir "))
                       (output-file (let ((ido-everywhere nil))
                                      (read-file-name "Output file "
-                                                     input-dir nil nil
+                                                     (file-name-as-directory input-dir) nil nil
                                                      ".yas-compiled-snippets.el"
                                                      nil))))
                  (list input-dir output-file)))
@@ -1756,8 +1756,13 @@ Prompts for INPUT-DIR and OUTPUT-FILE if called-interactively"
                 (insert (format ";;; %s - automatically compiled snippets for `%s' end here\n"
                                 (file-name-nondirectory output-file) mode))
                 (insert ";;;"))))
-        (yas/load-directory-1 input-dir nil nil 'no-compiled-snippets))))
-  
+        (let ((major-mode-and-parents (yas/compute-major-mode-and-parents
+                                       (concat (file-name-as-directory input-dir) "dummy"))))
+          (yas/load-directory-1 input-dir
+                                (car major-mode-and-parents)
+                                (cdr major-mode-and-parents)
+                                'no-compiled-snippets)))))
+
   (if (and (called-interactively-p)
            (yes-or-no-p (format "Open the resulting file (%s)? "
                                 (expand-file-name output-file))))


### PR DESCRIPTION
This fixes the problem with mode not being set at .yas-compiled-snippets.el generated files.
