### PR TITLE
yas/ido-prompt: play nice with autoloading of ido-completing-read

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -1551,7 +1551,7 @@ TEMPLATES is a list of `yas/template'."
         (keyboard-quit))))
 
 (defun yas/ido-prompt (prompt choices &optional display-fn)
-  (when (featurep 'ido)
+  (when (fboundp 'ido-completing-read)
     (yas/completing-prompt prompt choices display-fn #'ido-completing-read)))
 
 (eval-when-compile (require 'dropdown-list nil t))


### PR DESCRIPTION
Hi!

The check in ido-prompt is overly strict, because it doesn't work with autoloading: I put `(autoload ido-completing-read "ido" DOCSTRING)` into my init file and I'm able to call this function, but yasnippet will never allow it awaiting for `ido` feature.
