### PR TITLE
Set default Encoding to UTF_8 for Ruby 1.9

### DIFF
--- a/extras/textmate_import.rb
+++ b/extras/textmate_import.rb
@@ -19,6 +19,7 @@ require 'fileutils'
 require 'shellwords' # String#shellescape
 require 'ruby-debug' if $DEBUG
 
+Encoding.default_external = Encoding::UTF_8 if RUBY_VERSION > '1.8.7'
 
 opts = Trollop::options do
   opt :bundle_dir, "TextMate bundle directory", :short => '-d', :type => :string


### PR DESCRIPTION
Running `rake convert_bundles` on Ruby 1.9 will cause `invalid byte sequence in US-ASCII` exception.

```
Converting from extras/bundles/html-tmbundle
./extras/textmate_import.rb -d extras/bundles/html-tmbundle -o ./extras/imported/html-mode -q
./extras/textmate_import.rb:362:in `split': invalid byte sequence in US-ASCII (ArgumentError)
from ./extras/textmate_import.rb:362:in `block in <main>'
from ./extras/textmate_import.rb:360:in `open'
from ./extras/textmate_import.rb:360:in `<main>'
rake aborted!
Command failed with status (1): [./extras/textmate_import.rb -d extras/bund...]
```

This is because Ruby 1.9 isn't reading files in UTF-8 by default and is dependent on system locale. Setting `Encoding.default_external = Encoding::UTF_8` fixes the issue.
