### PR TITLE
bug fix for hippie, and feature implementation to allow snippet expansion in minibuffer 

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -812,8 +812,13 @@ Key bindings:
          (remove-hook 'emulation-mode-map-alists 'yas/direct-keymaps))))
 
 
-(defvar yas/dont-activate nil
+(defvar yas/dont-activate '(minibufferp)
   "If non-nil don't let `yas/minor-mode-on' active yas for this buffer.
+
+If a function, then its result is used.
+
+If a list of functions, then all functions must return nil to
+activate yas for this buffer.
 
 `yas/minor-mode-on' is usually called by `yas/global-mode' so
 this effectively lets you define exceptions to the \"global\"
@@ -825,10 +830,11 @@ behaviour. Can also be a function of zero arguments.")
 
 Do this unless `yas/dont-activate' is truish "
   (interactive)
-  (unless (or (minibufferp)
-              (if (functionp yas/dont-activate)
-                  (funcall yas/dont-activate)
-                yas/dont-activate))
+  (unless (cond ((functionp yas/dont-activate)
+                 (funcall yas/dont-activate))
+                ((consp yas/dont-activate)
+                 (some #'funcall yas/dont-activate))
+                (yas/dont-activate))
     ;; Load all snippets definitions unless we still don't have a
     ;; root-directory or some snippets have already been loaded.
     ;;


### PR DESCRIPTION
bug fix: make hippie try function respect minor-mode

feature: make it user configurable whether snippets are enabled in minibuffer or not.  

I need this feature because I have snippets specifically for the minibuffer.
