### PR TITLE
Added compile upon load option.  Added bug-fix for the interactive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ pkg/
 extras/imported/**
 !extras/imported/*/.yas-setup.el
 *.elc
+.yas-compiled-snippets.el
+.yas-compiled-snippets.elc


### PR DESCRIPTION
This pull request adds:
- Automatic compiling of snippet directories that have not been compiled yet.
- Automatic deletion of snippet compilation when editing snippets in the directory with a compiled snippet load file.
- Automatic deletion of snippet compilation files with "Reload All"
- Add the option of including the snippet file name in the compiled snippets.  It will allow you to edit the snippets, and still have the compiled snippets be loaded.

In addition, I have a bug fix for the following issue
- When interactively calling "Reload All" from the menu when JIT loading is enabled, the snippets are not reloaded.  This small bug fix changes that.
