### PR TITLE
Add `mod` snippet to ruby-mode for `module` definitions

### DIFF
--- a/snippets/ruby-mode/definitions/mod
+++ b/snippets/ruby-mode/definitions/mod
@@ -1,0 +1,13 @@
+# name: module ... end
+# contributor: hitesh <hitesh.jasani@gmail.com>, jimeh <contact@jimeh.me>
+# key: mod
+# --
+module ${1:`(let ((fn (capitalize (file-name-nondirectory
+                                 (file-name-sans-extension
+         (or (buffer-file-name)
+             (buffer-name (current-buffer))))))))
+           (cond
+             ((string-match "_" fn) (replace-match "" nil nil fn))
+              (t fn)))`}
+  $0
+end


### PR DESCRIPTION
Modified the `class ... end` snippet for `module ... end`.
