### PR TITLE
add pdb snippet to python-mode

### DIFF
--- a/snippets/python-mode/pdb
+++ b/snippets/python-mode/pdb
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# name: pdb
+# contributor: Ionuț Arțăriși
+# --
+import pdb;pdb.set_trace()


### PR DESCRIPTION
This makes it a lot easier to type the pdb the typical line used to break into the debugger: http://docs.python.org/library/pdb.html
