### PR TITLE
quieten byte-compiler

### DIFF
--- a/dropdown-list.el
+++ b/dropdown-list.el
@@ -250,4 +250,5 @@ Use multiple times to bind different COMMANDs to the same KEY."
 ;;; dropdown-list.el ends here
 ;; Local Variables:
 ;; coding: utf-8
+;; byte-compile-warnings: (not cl-functions)
 ;; End:

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -136,6 +136,15 @@
 (require 'easymenu)
 (require 'help-mode)
 
+(eval-when-compile
+  (defvar yas--editing-template)
+  (defvar yas--guessed-modes)
+  (defvar yas--indent-original-column)
+  (defvar yas--scheduled-jit-loads)
+  (defvar yas-keymap)
+  (defvar yas-selected-text)
+  (defvar yas-verbosity))
+
 
 ;;; User customizable variables
 
@@ -1849,7 +1858,7 @@ This works by stubbing a few functions, then calling
             (when (file-exists-p elfile)
               (insert ";;; .yas-setup.el support file if any:\n;;;\n")
               (insert-file-contents elfile)
-              (end-of-buffer)
+              (goto-char (point-max))
               )))
          (yas-define-snippets
           (mode snippets)
@@ -4564,4 +4573,5 @@ upon.")
 ;;; yasnippet.el ends here
 ;; Local Variables:
 ;; coding: utf-8
+;; byte-compile-warnings: (not cl-functions)
 ;; End:


### PR DESCRIPTION
These changes quieten most byte-compiler warnings, with the aim of making installation via package.el go more smoothly.

The following warnings remain

```
yasnippet.el:1712:14:Warning: `interactive-p' is an obsolete function (as of 23.2); use `called-interactively-p' instead.
yasnippet.el:1935:8:Warning: function `yas-define-snippets' defined multiple times in this file
yasnippet.el:4578:1:Warning: the following functions are not known to be defined: dropdown-list, yas-define-snippets
```

I could address them, but the fixes would be more complex and/or raise compatibility issues with older versions of Emacs.
