### PR TITLE
future-proof against obsoleting of `flet`

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -136,6 +136,8 @@
 (require 'easymenu)
 (require 'help-mode)
 
+;; Future-proof against obsoleting flet, per discussion at
+;; http://github.com/capitaomorte/yasnippet/issues/324
 (eval-and-compile
   (unless (fboundp 'cl-flet)
     (defalias 'cl-flet 'flet)


### PR DESCRIPTION
flet will be marked obsolete starting in Emacs 24.3 in favor of `cl-flet` (or `labels`)

This is not an issue with any currently-released version of Emacs.
