### PR TITLE
buffer-local variable cannot control global behavior

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -753,7 +753,6 @@ activate yas for this buffer.
 `yas-minor-mode-on' is usually called by `yas-global-mode' so
 this effectively lets you define exceptions to the \"global\"
 behaviour. Can also be a function of zero arguments.")
-(make-variable-buffer-local 'yas-dont-activate)
 
 (defun yas-minor-mode-on ()
   "Turn on YASnippet minor mode.


### PR DESCRIPTION
I think this is a bug: if  `yas-dont-activate` is always buffer-local, then setting it won't modify global behavior as it is documented to do. (unless the user somehow knows to use `setq-default`)
