### PR TITLE
make yas--called-interactively-p compatible with trunk

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -1311,9 +1311,13 @@ them all in `yas--menu-table'"
 
 Optional KIND is as documented at `called-interactively-p'
 in GNU Emacs 24.1 or higher."
-  (if (eq 0 (cdr (subr-arity (symbol-function 'called-interactively-p))))
-      '(called-interactively-p)
-    `(called-interactively-p ,kind)))
+  (if (condition-case nil
+	  (progn
+	    (called-interactively-p 'any)
+	    t)
+	(error nil))
+      `(called-interactively-p ,kind)
+    '(called-interactively-p)))
 
 
 (defun yas--call-with-temporary-redefinitions (function


### PR DESCRIPTION
This code is less clean, but does address the problem
@dgutov brought up in (closed) issue #328.  Tested
in 22.2.1, 23.3.1, 24.2.1, 24.3.50.1/21.Nov.2012.
