### PR TITLE
Remove group-name prefix from ruby-mode/collections/zip

### DIFF
--- a/snippets/ruby-mode/collections/zip
+++ b/snippets/ruby-mode/collections/zip
@@ -1,4 +1,4 @@
 #name : zip(...) { |...| ... }
-# key: collectionszip
+# key: zip
 # --
 zip(${enums}) { |${row}| $0 }


### PR DESCRIPTION
Bug introduced in f48317e7c5ecdbb7680d0ea2c595cfda0342c3bb and missed in 3aea27042bc2a0f05b2755e0c5c4edc43b426aed.
