### PR TITLE
Make yas--version compatible with version-to-list()

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -475,7 +475,7 @@ snippet itself contains a condition that returns the symbol
 
 ;;; Internal variables
 
-(defvar yas--version "0.8.0 (beta)")
+(defvar yas--version "0.8.0beta")
 
 (defvar yas--menu-table (make-hash-table)
   "A hash table of MAJOR-MODE symbols to menu keymaps.")


### PR DESCRIPTION
Hi,

I want to use some functions of YASnippet, but the API changed between some versions ( _I'm not complaining, I'm totally fine with that_ ), so I have to check the version of YASnippet.

Emacs has some standard functions to deal with versioning, it handles `minor, major, beta` and so on but there is some restriction on a version string.

My current of YASnippet is:

```
 yas--version ; "0.8.0 (beta)"
```

It contains some parentheses (I don't know yet for older versions), which break `version-to-list` and similar functions (`version<`, `vesion<=`, ...)

`version-to-list` documentation explains the valid formats of versions, a quick (and correct IMHO) solution is to change the value of `yas--version` to `"0.8.0beta"`.

And thank you for making YASnippet!
