### PR TITLE
Fix yas--font-lock-keywords

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -814,8 +814,6 @@ Honour `yas-dont-activate', which see."
 
 (defvar yas--font-lock-keywords
   (append '(("^#.*$" . font-lock-comment-face))
-          lisp-font-lock-keywords
-          lisp-font-lock-keywords-1
           lisp-font-lock-keywords-2
           '(("$\\([0-9]+\\)"
              (0 font-lock-keyword-face)


### PR DESCRIPTION
With `GNU Emacs 24.3.1`
and latest master (d963c41a147a7d7f9ed09ee71bc8ce3065ad7eb6), do:
`emacs -Q -L . -l yasnippet.el --eval "(setq vc-handled-backends nil)" snippets/c-mode/printf`
The `*Messages*` buffer now contains:

```
For information about GNU Emacs and the GNU system, type C-h C-a.
Error during redisplay: (jit-lock-function 1) signaled (void-function font-lock-keyword-face)
```

The `vc-handled-backends` isn't strictly necessary, I was just ruling out an interaction with `vc` code.

---

Problem appears to be that `yas--font-lock-keywords` has the wrong syntax. While debugging this, I noticed duplicate entries in `font-lock-keywords` because `lisp-font-lock-keywords2` already contains all the entries in `lisp-font-lock-keywords` and `lisp-font-lock-keywords1`.
