### PR TITLE
inhibit change hooks during (insert content)

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3523,9 +3523,11 @@ considered when expanding the snippet."
                  (setq snippet
                        (if expand-env
                            (eval `(let* ,expand-env
-                                    (insert content)
+                                    (let ((inhibit-modification-hooks t))
+                                      (insert content))
                                     (yas--snippet-create (point-min))))
-                         (insert content)
+                         (let ((inhibit-modification-hooks t))
+                           (insert content))
                          (yas--snippet-create (point-min)))))))
 
            ;; stacked-expansion: This checks for stacked expansion, save the


### PR DESCRIPTION
I reproduced the problem with

``` elisp
(progn
  (switch-to-buffer "test.cc")
  (c++-mode)
  (insert "#include <foo>\n")
  (save-restriction
    (narrow-to-region (point) (point))
    (insert "main")))
```

This corresponds to the `(insert content)` in `yas-expand-snippet`.

It's something about the 0 size region that cc-mode doesn't like. I don't understand 100% why this is (`cc-mode` is too complicated for mortals to understand) but inhibiting cc-mode's change hooks solves the issue for me.
