### PR TITLE
Update documentation for organizing snippets

### DIFF
--- a/snippet-organization.html
+++ b/snippet-organization.html
@@ -65,7 +65,7 @@
 </li>
 <li><a class="reference internal" href="#yasnippet-bundle" id="id7">YASnippet bundle</a></li>
 <li><a class="reference internal" href="#customizable-variables" id="id8">Customizable variables</a><ul>
-<li><a class="reference internal" href="#yas-root-directory" id="id9"><tt class="docutils literal"><span class="pre">yas/root-directory</span></tt></a></li>
+<li><a class="reference internal" href="#yas-snippet-dirs" id="id9"><tt class="docutils literal"><span class="pre">yas-snippet-dirs</span></tt></a></li>
 <li><a class="reference internal" href="#yas-ignore-filenames-as-triggers" id="id10"><tt class="docutils literal"><span class="pre">yas/ignore-filenames-as-triggers</span></tt></a></li>
 </ul>
 </li>
@@ -125,7 +125,7 @@ also create or download more directories.</p>
 
 <div class="section" id="id2">
 <h1><a class="toc-backref" href="#id4">Organizing snippets</a></h1>
-<p>Once you've setup <tt class="docutils literal"><span class="pre">yas/root-directory</span></tt> , you can store snippets
+<p>Once you've setup <tt class="docutils literal"><span class="pre">yas-snippet-dirs</span></tt> , you can store snippets
 inside sub-directories of these directories.</p>
 <p>Snippet definitions are put in plain text files. They are arranged
 by sub-directories, and the snippet tables are named after these
@@ -207,15 +207,27 @@ generated this way.</p>
 </div>
 <div class="section" id="customizable-variables">
 <h1><a class="toc-backref" href="#id8">Customizable variables</a></h1>
-<div class="section" id="yas-root-directory">
-<h2><a class="toc-backref" href="#id9"><tt class="docutils literal"><span class="pre">yas/root-directory</span></tt></a></h2>
-<p>Root directory that stores the snippets for each major mode.</p>
-<p>If you set this from your .emacs, can also be a list of strings,
-for multiple root directories. If you make this a list, the first
-element is always the user-created snippets directory. Other
-directories are used for bulk reloading of all snippets using
-<tt class="docutils literal"><span class="pre">yas/reload-all</span></tt></p>
+<div class="section" id="yas-snippet-dirs">
+
+<h2>
+  <a class="toc-backref" href="#id9"><tt class="docutils literal"><span class="pre">yas-snippet-dirs</span></tt></a>
+</h2>
+
+<p>
+  List of directories that store the snippets for each major mode.
+</p>
+
+<p>
+  The first element of the list is always the user-created snippets
+  directory. Other directories are used for bulk reloading of all snippets
+  using
+  <tt class="docutils literal">
+    <span class="pre">yas/reload-all</span>
+  </tt>.
+</p>
+
 </div>
+
 <div class="section" id="yas-ignore-filenames-as-triggers">
 <h2><a class="toc-backref" href="#id10"><tt class="docutils literal"><span class="pre">yas/ignore-filenames-as-triggers</span></tt></a></h2>
 <p>If non-nil, don't derive tab triggers from filenames.</p>


### PR DESCRIPTION
Update docs to use `yas-snippet-dirs` instead of `yas/root-directory`. See #413 (which is merged with #416).
