### PR TITLE
Feature: de/activate-extra-mode

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -569,6 +569,31 @@ TODO: be meaner"
     (should (eq (key-binding [(tab)]) 'yas-expand))
     (should (eq (key-binding (kbd "TAB")) 'yas-expand))))
 
+(ert-deftest test-yas-activate-extra-modes ()
+  "Given a symbol, `yas-activate-extra-mode' should be able to
+add the snippets associated with the given mode."
+  (with-temp-buffer
+    (emacs-lisp-mode)
+    (yas-minor-mode-on)
+    (yas-activate-extra-mode 'markdown-mode)
+    (should (eq 'markdown-mode (car yas--extra-modes)))
+    (yas-should-expand '(("_" . "_Text_ ")))
+    (yas-should-expand '(("car" . "(car )")))))
+
+(ert-deftest test-yas-deactivate-extra-modes ()
+  "Given a symbol, `yas-deactive-extra-mode' should be able to
+remove one of the extra modes that is present in the current
+buffer."
+  (with-temp-buffer
+    (emacs-lisp-mode)
+    (yas-minor-mode-on)
+    (yas-activate-extra-mode 'markdown-mode)
+    (should (eq 'markdown-mode (car yas--extra-modes)))
+    (yas-deactivate-extra-mode 'markdown-mode)
+    (should-not (eq 'markdown-mode (car yas--extra-modes)))
+    (yas-should-not-expand '("_"))
+    (yas-should-expand '(("car" . "(car )")))))
+
 
 ;;; Helpers
 ;;;

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2008-2013 Free Software Foundation, Inc.
 ;; Authors: pluskid <pluskid@gmail.com>,  João Távora <joaotavora@gmail.com>
 ;; Maintainer: João Távora <joaotavora@gmail.com>
-;; Version: 0.8.0
+;; Version: 0.8.1
 ;; Package-version: 0.8.0
 ;; X-URL: http://github.com/capitaomorte/yasnippet
 ;; Keywords: convenience, emulation
@@ -48,13 +48,6 @@
 ;;           The deprecated `yas/root-directory' aliases this variable
 ;;           for backward-compatibility.
 ;;
-;;       `yas-extra-modes'
-;;
-;;           A local variable that you can set in a hook to override
-;;           snippet-lookup based on major mode.  It is a list of
-;;           symbols that correspond to subdirectories of
-;;           `yas-snippet-dirs' and is used for deciding which
-;;           snippets to consider for the active buffer.
 ;;
 ;;   Major commands are:
 ;;
@@ -67,6 +60,11 @@
 ;;       M-x yas-load-directory
 ;;
 ;;           Prompts you for a directory hierarchy of snippets to load.
+;;
+;;       M-x yas-activate-extra-mode
+;;
+;;           Prompts you for an extra mode to add snippets for in the
+;;           current buffer.
 ;;
 ;;       M-x yas-insert-snippet
 ;;
@@ -309,7 +307,7 @@ When non-nil, submenus for each snippet table will be listed
 under the menu \"Yasnippet\".
 
 - If set to `abbreviate', only the current major-mode
-menu and the modes set in `yas-extra-modes' are listed.
+menu and the modes set in `yas--extra-modes' are listed.
 
 - If set to `full', every submenu is listed
 
@@ -657,11 +655,12 @@ snippet itself contains a condition that returns the symbol
 (defvar yas-minor-mode-map (yas--init-minor-keymap)
   "The keymap used when `yas-minor-mode' is active.")
 
-(defvar yas-extra-modes nil
-  "A list of modes for which to also lookup snippets.
+(defvar yas--extra-modes nil
+  "An internal list of modes for which to also lookup snippets.
 
 This variable probably makes more sense as buffer-local, so
 ensure your use `make-local-variable' when you set it.")
+(define-obsolete-variable-alias 'yas-extra-modes 'yas--extra-modes "0.8.1")
 
 (defvar yas--tables (make-hash-table)
   "A hash table of mode symbols to `yas--table' objects.")
@@ -713,7 +712,7 @@ and friends."
 
                             unless (memq neighbour explored)
                             append (funcall dfs neighbour explored)))))
-    (remove-duplicates (append yas-extra-modes
+    (remove-duplicates (append yas--extra-modes
                                (funcall dfs major-mode)))))
 
 (defvar yas-minor-mode-hook nil
@@ -761,6 +760,37 @@ Key bindings:
          ;;
          (remove-hook 'post-command-hook 'yas--post-command-handler t)
          (remove-hook 'emulation-mode-map-alists 'yas--direct-keymaps))))
+
+(defun yas-activate-extra-mode (mode)
+  "Activates the snippets for the given `mode' in the buffer.
+
+The function can be called in the hook of a minor mode to
+activate snippets associated with that mode."
+  (interactive
+   (let (modes
+         symbol)
+     (maphash (lambda (k _)
+                (setq modes (cons (list k) modes)))
+              yas--parents)
+     (setq symbol (completing-read
+                   "Activate mode: " modes nil t))
+     (list
+      (when (not (string= "" symbol))
+        (intern symbol)))))
+  (when mode
+    (make-variable-buffer-local 'yas--extra-modes)
+    (add-to-list 'yas--extra-modes mode)
+    (yas--load-pending-jits)))
+
+(defun yas-deactivate-extra-mode (mode)
+  "Deactivates the snippets for the given `mode' in the buffer."
+  (interactive
+   (list (intern
+          (completing-read
+           "Deactivate mode: " (mapcar #'list yas--extra-modes) nil t))))
+  (setq yas--extra-modes
+        (remove mode
+                yas--extra-modes)))
 
 (defvar yas-dont-activate '(minibufferp)
   "If non-nil don't let `yas-global-mode' affect some buffers.
@@ -888,8 +918,8 @@ Has the following fields:
 `yas--table-name'
 
   A symbol name normally corresponding to a major mode, but can
-  also be a pseudo major-mode to be referenced in
-  `yas-extra-modes', for example.
+  also be a pseudo major-mode to be used in
+  `yas-activate-extra-mode', for example.
 
 `yas--table-hash'
 


### PR DESCRIPTION
Adds functionality to deactivate/activate extra modes. Two new functions
are added: `activate-extra-mode`, `deactivate-extra-mode`. These two
functions activate and deactivate snippets for the given mode in the
current buffer. The use-case for the functions is to have a simple
interface for adding new snippets when activating a new minor mode.

The previous way of doing this, using `yas-extra-modes`, is made
obsolete and the new deactivate/activate should be the preferred
instead. The reason for making `yas-extra-modes' obsolete is to keep a
simple interface.

`yas-activate-extra-mode` will auto-complete on the currently available
modes. `yas-deactivate-extra-mode` will auto-complete on the active 
extra modes.

See issue #420 for more information.

Please tell me of there are any problems. Emacs Lisp is not my strongest
language and there might be something that I have missed.
