### PR TITLE
Adding subsection to rst-mode

### DIFF
--- a/snippets/rst-mode/subsec
+++ b/snippets/rst-mode/subsec
@@ -4,3 +4,4 @@
 # --
 ${1:Subsection}
 ${1:$(make-string (string-width yas-text) ?\+)}
+


### PR DESCRIPTION
I found that sometimes 3 levels of headlines are not enough, so created subsection with '++++' (Tested on sphinx-doc and is working as expected). This is minor change but can be heandy for some people.
