### PR TITLE
yas-ido-prompt: fix reversed choice list

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -1597,7 +1597,7 @@ Optional PROMPT sets the prompt to use."
   (when (and (fboundp 'ido-completing-read)
 	     (or (>= emacs-major-version 24)
 		 ido-mode))
-    (yas-completing-prompt prompt choices display-fn #'ido-completing-read)))
+    (yas-completing-prompt prompt (reverse choices) display-fn #'ido-completing-read)))
 
 (defun yas-dropdown-prompt (_prompt choices &optional display-fn)
   (when (fboundp 'dropdown-list)


### PR DESCRIPTION
The list of choices gets reversed in yas-completing-prompt.  Replace
choices by (reverse choices) in yas-ido-prompt so that the list
presented to the user is in the same order as in the snippet.
