### PR TITLE
yasnippet templates don't add newlines

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -185,7 +185,7 @@ as the default for storing the user's new snippets."
 (defvaralias 'yas/root-directory 'yas-snippet-dirs)
 
 (defcustom yas-new-snippet-default "\
-# -*- mode: snippet -*-
+# -*- mode: snippet; require-final-newline: nil -*-
 # name: $1
 # key: ${2:${1:$(yas--key-from-desc yas-text)}}${3:
 # binding: ${4:direct-keybinding}}${5:


### PR DESCRIPTION
For most snippets I don't want the extra newline so I thought it'd be nice to have it by default.

If it makes sense to have it for everyone, merge at will :)
