### PR TITLE
Closes #474: fix more cc-mode font-lock conflicts

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -229,7 +229,7 @@
     (c-mode)
     (yas-minor-mode 1)
     (insert "#include <foo>\n")
-    (let ((yas-good-grace nil)) (yas-expand-snippet "`(insert \"TODO: \")`"))
+    (let ((yas-good-grace nil)) (yas-expand-snippet "`\"TODO: \"`"))
     (should (string= (yas--buffer-contents) "#include <foo>\nTODO: "))))
 
 (ert-deftest example-for-issue-404 ()

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3911,9 +3911,11 @@ with their evaluated value into `yas--backquote-markers-and-strings'."
       (goto-char (match-beginning 0))
       (when transformed
         (let ((marker (make-marker)))
-          (insert "Y") ;; quite horrendous, I love it :)
-          (set-marker marker (point))
-          (insert "Y")
+          (save-restriction
+            (widen)
+            (insert "Y") ;; quite horrendous, I love it :)
+            (set-marker marker (point))
+            (insert "Y"))
           (push (cons marker transformed) yas--backquote-markers-and-strings))))))
 
 (defun yas--restore-backquotes ()
@@ -3924,9 +3926,11 @@ with their evaluated value into `yas--backquote-markers-and-strings'."
            (string (cdr marker-and-string)))
       (save-excursion
         (goto-char marker)
-        (delete-char -1)
-        (insert string)
-        (delete-char 1)
+        (save-restriction
+          (widen)
+          (delete-char -1)
+          (insert string)
+          (delete-char 1))
         (set-marker marker nil)))))
 
 (defun yas--scan-sexps (from count)


### PR DESCRIPTION
- yasnippet-tests.el (example-for-issue-474): Don't call insert from
  within backquotes, it's redundant and prevents proper testing of
  backquote expansion.
- yasnippet.el (yas--restore-backquotes, yas--save-backquotes): Ensure
  the buffer isn't narrowed while modifying it to avoid conflicting with
  cc-mode fontification.
#474 in the title doesn't count as a reference.
