### PR TITLE
More yas-key-syntaxes functions

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -351,7 +351,8 @@ TODO: correct this bug!"
              (yas--foobarbaz t) (yas--barbaz t))
          (yas-should-expand '(("foo-barbaz" . "foo-barOKbazOK")))
          (setq yas-key-syntaxes '(yas-longest-key-from-whitespace))
-         (yas-should-expand '(("foo-barbaz" . "OKfoo-barbazOK"))))))))
+         (yas-should-expand '(("foo-barbaz" . "OKfoo-barbazOK")
+                              ("foo " . "foo "))))))))
 
 
 ;;; Loading

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -2749,7 +2749,7 @@ marks it as something else (typically comment ender)."
   (if (= (point) start-point)
       (yas-try-key-from-whitespace start-point)
     (forward-char))
-  (unless (= original (1+ (point)))
+  (unless (<= start-point (1+ (point)))
     'again))
 
 


### PR DESCRIPTION
As discussed in #497, I've added some example functions for `yas-key-syntaxes`, and added the `start-point` parameter. I replaced `"^ "` with `yas-try-key-from-whitespace` in the default value of `yas-key-syntaxes`, since I think that implements the original intention better anyway.
