### PR TITLE
Compatibility with custom-unlispify-remove-prefixes

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -148,6 +148,7 @@
 
 (defgroup yasnippet nil
   "Yet Another Snippet extension"
+  :prefix "yas-"
   :group 'editing)
 
 (defvar yas-installed-snippets-dir nil)


### PR DESCRIPTION
Adds group prefix for compatibility with `custom-unlispify-remove-prefixes`
