### PR TITLE
Added auto-trigger support for single-key commands

### DIFF
--- a/doc/snippet-development.org
+++ b/doc/snippet-development.org
@@ -169,6 +169,12 @@ This binding will be recorded in the keymap =html-mode-map=. To expand a
 paragraph tag newlines, just press =C-u C-c C-c C-m=. Omitting the =C-u=
 will expand the paragraph tag without newlines.
 
+** =# trigger:= =auto=
+    
+If =trigger= is set to =auto=, the snippet will automatically expand
+when the =key= (or if =key= is not defined, the key corresponding to =name=)
+is pressed.
+
 ** =# type:= =snippet= or =command=
 
 If the =type= directive is set to =command=, the body of the snippet

--- a/doc/snippet-expansion.org
+++ b/doc/snippet-expansion.org
@@ -118,6 +118,11 @@ YASnippet menu has the same effect of evaluating the follow code:
 See the internal documentation on [[sym:yas-expand-snippet][=yas-expand-snippet=]] for more
 information.
 
+** Automatically expanding snippets
+
+You may not want to press the *trigger key* to expand certain snippets. See
+[[file:snippet-development.org][Writing Snippets]] to learn how to automatically expand certain snippets.
+
 * Controlling expansion
 
 ** Eligible snippets


### PR DESCRIPTION
With these changes, you can disable `smartparens-mode` and handle parentheses and quotation matching entirely through yasnippet. I added a new key `trigger` to the snippet definition file to support this behavior. Here is how you would define a snippet to automatically match parentheses.

```
# -*- mode: snippet; require-final-newline: nil -*-
# name: (
# key: (
# binding: direct-keybinding
# trigger: auto
# --
($1)$0
```
