### PR TITLE
Fix transform on exit

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3065,11 +3065,13 @@ If there's none, exit the snippet."
     ;;
     (when (and active-field
                (yas--field-transform active-field))
-      (let* ((yas-moving-away-p t)
+      (let* ((inhibit-modification-hooks t)
+             (yas-moving-away-p t)
              (yas-text (yas--field-text-for-display active-field))
              (yas-modified-p (yas--field-modified-p active-field)))
         ;; primary field transform: exit call to field-transform
-        (yas--eval-lisp (yas--field-transform active-field))))
+        (yas-replace-field-contents active-field
+                                    (yas--eval-lisp (yas--field-transform active-field)))))
     ;; Now actually move...
     (cond ((and target-pos (>= target-pos (length live-fields)))
            (yas-exit-snippet snippet))
@@ -4239,18 +4241,21 @@ When multiple expressions are found, only the last one counts."
   (when (yas--field-transform field)
     (let ((transformed (and (not (eq (yas--field-number field) 0))
                             (yas--apply-transform field field))))
-      (when (and transformed
-                 (not (string= transformed (buffer-substring-no-properties (yas--field-start field)
-                                                                           (yas--field-end field)))))
-        (setf (yas--field-modified-p field) t)
-        (goto-char (yas--field-start field))
-        (yas--inhibit-overlay-hooks
-          (insert transformed)
-          (if (> (yas--field-end field) (point))
-              (delete-region (point) (yas--field-end field))
-            (set-marker (yas--field-end field) (point))
-            (yas--advance-start-maybe (yas--field-next field) (point)))
-          t)))))
+      (yas-replace-field-contents field transformed))))
+
+(defun yas-replace-field-contents (field contents)
+  (when (and contents
+             (not (string= contents (buffer-substring-no-properties
+                                     (yas--field-start field)
+                                     (yas--field-end field)))))
+  (setf (yas-field-modified-p field) t)
+  (goto-char (yas-field-start field))
+  (insert contents)
+  (if (> (yas-field-end field) (point))
+      (delete-region (point) (yas-field-end field))
+    (set-marker (yas-field-end field) (point))
+    (yas-advance-start-maybe (yas-field-next field) (point)))
+  t))
 
 
 ;;; Post-command hook:

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3065,8 +3065,7 @@ If there's none, exit the snippet."
     ;;
     (when (and active-field
                (yas--field-transform active-field))
-      (let* ((inhibit-modification-hooks t)
-             (yas-moving-away-p t)
+      (let* ((yas-moving-away-p t)
              (yas-text (yas--field-text-for-display active-field))
              (yas-modified-p (yas--field-modified-p active-field)))
         ;; primary field transform: exit call to field-transform
@@ -4248,13 +4247,13 @@ When multiple expressions are found, only the last one counts."
              (not (string= contents (buffer-substring-no-properties
                                      (yas--field-start field)
                                      (yas--field-end field)))))
-  (setf (yas-field-modified-p field) t)
-  (goto-char (yas-field-start field))
+  (setf (yas--field-modified-p field) t)
+  (goto-char (yas--field-start field))
   (insert contents)
-  (if (> (yas-field-end field) (point))
-      (delete-region (point) (yas-field-end field))
-    (set-marker (yas-field-end field) (point))
-    (yas-advance-start-maybe (yas-field-next field) (point)))
+  (if (> (yas--field-end field) (point))
+      (delete-region (point) (yas--field-end field))
+    (set-marker (yas--field-end field) (point))
+    (yas-advance-start-maybe (yas--field-next field) (point)))
   t))
 
 


### PR DESCRIPTION
Prospectively fixes #381

I tried the following snippet (requires s.el) for pascal source code without the patch:

```
# -*- mode: snippet; require-final-newline: nil -*-
# name: procedure
# key: p
# group: control
# binding: direct-keybinding
# --
procedure ${1:DoSomething$(if yas-moving-away-p (s-upper-camel-case yas-text) yas-text)}($2);
begin
$0
end;
```

Casing is not adjusted correctly when leaving the $1 mirror.  With this patch applied, it will correctly update the mirror.  I have longer snippets where such transformed mirrors take place in more than one location, each mirror is properly updated in those cases as well.  An example of such a snippet:

```
# -*- mode: snippet; require-final-newline: nil -*-
# name: property
# key: property
# group: types
# binding: direct-keybinding
# --
function $3 : $2;
procedure $4(${5:some-property$(if yas-moving-away-p (s-upper-camel-case yas-text) yas-text)}: $2);
property ${1:some-property$(if yas-moving-away-p (s-upper-camel-case yas-text) yas-text)} : ${2:some-type$(if yas-moving-away-p (s-upper-camel-case yas-text) yas-text)} Read ${3:get-$1$(if yas-moving-away-p (s-upper-camel-case yas-text) yas-text)} Write ${4:set-$1$(if yas-moving-away-p (s-upper-camel-case yas-text) yas-text)};
```

I took this patch from Google Groups, updated it to the yas- namespace and removed the inhibition of update hooks when moving between mirrors.  I have been using this configuration for several weeks without incident; it may be useful for others.

https://groups.google.com/forum/#!original/smart-snippet/HEJ5JLIXhp8/DQTdvDHhOHIJ
