### PR TITLE
Add yas-lookup-snippet

### DIFF
--- a/doc/snippet-expansion.org
+++ b/doc/snippet-expansion.org
@@ -102,9 +102,8 @@ prefer.
 
 ** Expanding from emacs-lisp code
 
-Sometimes you might want to expand a snippet directly from you own
-elisp code. You should call
-[[sym:yas-expand-snippet][=yas-expand-snippet=]] instead of
+Sometimes you might want to expand a snippet directly from your own
+elisp code. You should call [[sym:yas-expand-snippet][=yas-expand-snippet=]] instead of
 [[sym:yas-expand][=yas-expand=]] in this case.
 
 As with expanding from the menubar, the condition system and multiple

--- a/doc/snippet-expansion.org
+++ b/doc/snippet-expansion.org
@@ -104,18 +104,21 @@ prefer.
 
 Sometimes you might want to expand a snippet directly from your own
 elisp code. You should call [[sym:yas-expand-snippet][=yas-expand-snippet=]] instead of
-[[sym:yas-expand][=yas-expand=]] in this case.
+[[sym:yas-expand][=yas-expand=]] in this case. [[sym:yas-expand-snippet][=yas-expand-snippet=]] takes a string in
+snippet template syntax, if you want to expand an existing snippet you
+can use [[sym:yas-lookup-snippet][=yas-lookup-snippet=]] to find its contents by name.
 
 As with expanding from the menubar, the condition system and multiple
-candidates doesn't affect expansion. In fact, expanding from the
-YASnippet menu has the same effect of evaluating the follow code:
+candidates doesn't affect expansion (the condition system does affect
+[[sym:yas-lookup-snippet][=yas-lookup-snippet=]] though). In fact, expanding from the YASnippet
+menu has the same effect of evaluating the follow code:
 
 #+BEGIN_SRC emacs-lisp
   (yas-expand-snippet template)
 #+END_SRC
 
-See the internal documentation on [[sym:yas-expand-snippet][=yas-expand-snippet=]] for more
-information.
+See the internal documentation on [[sym:yas-expand-snippet][=yas-expand-snippet=]] and
+[[sym:yas-lookup-snippet][=yas-lookup-snippet=]] for more information.
 
 * Controlling expansion
 

--- a/doc/snippet-menu.org
+++ b/doc/snippet-menu.org
@@ -55,13 +55,12 @@ These customizations can also be found in the menu itself, under the
 
 The "Indenting" submenu contains options to control the values of
 [[sym:yas-indent-line][=yas-indent-line=]] and [[sym:yas-also-auto-indent-first-line][=yas-also-auto-indent-first-line=]]. See
-[[./snippet-development.org][Writing snippets]] .
+[[./snippet-development.org][Writing snippets]].
 
 * Prompting method
 
 The "Prompting method" submenu contains options to control the value of
-[[sym:yas-prompt-functions][=yas-prompt-functions=]]. See [[./snippet-expansion.org][Expanding
-snippets]] .
+[[sym:yas-prompt-functions][=yas-prompt-functions=]]. See [[./snippet-expansion.org][Expanding snippets]].
 
 * Misc
 

--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -433,6 +433,14 @@ TODO: correct this bug!"
           ("lisp-interaction-mode" ("sc" . "brother from another mother"))))
        ,@body))))
 
+(ert-deftest snippet-lookup ()
+  "Test `yas-lookup-snippet'."
+  (yas-with-some-interesting-snippet-dirs
+   (yas-reload-all 'no-jit)
+   (should (equal (yas-lookup-snippet "printf" 'c-mode) "printf($1);"))
+   (should (equal (yas-lookup-snippet "def" 'c-mode) "# define"))
+   (should-not (yas-lookup-snippet "no such snippet" nil 'noerror))
+   (should-not (yas-lookup-snippet "printf" 'emacs-lisp-mode 'noerror))))
 
 (ert-deftest basic-jit-loading ()
   "Test basic loading and expansion of snippets"


### PR DESCRIPTION
https://github.com/capitaomorte/yasnippet/issues/595#issuecomment-126965778:

> yas--all-templates is affected by yas-choose-tables-first and yas-choose-keys-first which should be let-bound to nil so the user isn't prompted like in interactive yas-expand. It's also affected by yas-buffer-local-condition, which should probably be turned off, but here I'm not so sure.

I made it honour `yas-buffer-local-condition` because it seems plausibly useful and the caller can always let-bind it themselves.

> My idea of the mode argument is that, if it is passed, then only the tables for that mode (and perhaps its parents) are used, but yas--extra-modes being buffer-local, cannot be used, so let-bind it to nil. If mode is not used, then use yas--get-snippet-tables as usual.

I made `yas--modes-to-activate` ignore `yas--extra-modes` only when passed a `mode` argument. I think it's useful to get snippet lookup as would occur in the current buffer when not passing any mode (similar rational behind not let-binding `yas-buffer-local-condition`).

> the function added should be yas-lookup-template (name &optional mode noerror). It's easy enough to use with the existing yas-expand-snippet. But you can add yas-expand-snippet-by-name too if you think it's very useful.

I left out `yas-expand-snippet-by-name` for now, it's fairly trivial anyway.

> - If noerror is passed, return nil instead of erroring out. Could be useful to probe for templates.
> - You probably will have to make changes to yas--get-snippet-tables and yas--modes-to-activate, adding optional mode arguments there. In yas--modes-to-activate it should obviously default to major-mode.

Yup.

> - Some docs would be needed, but I promise to write them if you provide the impl. :-)
> - Some tests would be nice, but I can write those too.

I added a mention in the docs, and a simple test. Perhaps those could be expanded some.

---

Note: currently `yas-lookup-snippet` only works on loaded tables, i.e. not-yet-jit-loaded tables are not considered.