### PR TITLE
Fix #619; find parents for extra-modes too

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -742,8 +742,7 @@ and friends."
                             append (funcall dfs neighbour explored)))))
     (remove-duplicates (if mode
                            (funcall dfs mode)
-                         (append yas--extra-modes
-                                 (funcall dfs major-mode))))))
+                         (apply #'append (mapcar dfs (cons major-mode yas--extra-modes)))))))
 
 (defvar yas-minor-mode-hook nil
   "Hook run when `yas-minor-mode' is turned on.")


### PR DESCRIPTION
```
* yasnippet.el (yas--modes-to-activate): Call dfs on yas--extra-modes as
  well.
```
---
This looks pretty straightforward, but I haven't test much for unexpected side effects.
