### PR TITLE
find parents for extra-modes too (v2)

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -741,10 +741,9 @@ and friends."
                                   (symbolp neighbour))
                         do (funcall dfs neighbour)))))
     (if mode
-        (progn (funcall dfs mode)
-               explored)
-      (funcall dfs major-mode)
-      (append yas--extra-modes explored))))
+        (funcall dfs mode)
+      (mapcar dfs (cons major-mode yas--extra-modes)))
+    explored))
 
 (defvar yas-minor-mode-hook nil
   "Hook run when `yas-minor-mode' is turned on.")

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -728,22 +728,23 @@ defined direct keybindings to the command
 (defun yas--modes-to-activate (&optional mode)
   "Compute list of mode symbols that are active for `yas-expand'
 and friends."
-  (let (dfs)
-    (setq dfs (lambda (mode &optional explored)
-                (push mode explored)
-                (cons mode
-                      (loop for neighbour
-                            in (cl-list* (get mode 'derived-mode-parent)
-                                         (ignore-errors (symbol-function mode))
-                                         (gethash mode yas--parents))
-                            when (and neighbour
-                                      (not (memq neighbour explored))
-                                      (symbolp neighbour))
-                            append (funcall dfs neighbour explored)))))
-    (remove-duplicates (if mode
-                           (funcall dfs mode)
-                         (append yas--extra-modes
-                                 (funcall dfs major-mode))))))
+  (let (dfs explored)
+    (setq dfs (lambda (mode)
+                (unless (memq mode explored)
+                  (push mode explored)
+                  (loop for neighbour
+                        in (cl-list* (get mode 'derived-mode-parent)
+                                     (ignore-errors (symbol-function mode))
+                                     (gethash mode yas--parents))
+                        when (and neighbour
+                                  (not (memq neighbour explored))
+                                  (symbolp neighbour))
+                        do (funcall dfs neighbour)))))
+    (if mode
+        (progn (funcall dfs mode)
+               explored)
+      (funcall dfs major-mode)
+      (append yas--extra-modes explored))))
 
 (defvar yas-minor-mode-hook nil
   "Hook run when `yas-minor-mode' is turned on.")


### PR DESCRIPTION
Removes [choice between `apply #'append` and `reduce #'append`][1] by removing need for either.

replace/ close #620.

[1]: https://github.com/capitaomorte/yasnippet/pull/620#commitcomment-13697599