### PR TITLE
Do not capture trailing whitespace when parsing

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -123,6 +123,15 @@
     (should (looking-at "ble"))
     (should (null (yas--snippets-at-point)))))
 
+(ert-deftest ignore-trailing-whitespace ()
+  (should (equal
+           (with-temp-buffer
+             (insert "# key: foo\n# --\nfoo")
+             (yas--parse-template))
+           (with-temp-buffer
+             (insert "# key: foo \n# --\nfoo")
+             (yas--parse-template)))))
+
 ;; (ert-deftest in-snippet-undo ()
 ;;   (with-temp-buffer
 ;;     (yas-minor-mode 1)

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -1448,7 +1448,7 @@ Here's a list of currently recognized directives:
                                                      (point-max)))
                (setq bound (point))
                (goto-char (point-min))
-               (while (re-search-forward "^# *\\([^ ]+?\\) *: *\\(.*\\)$" bound t)
+               (while (re-search-forward "^# *\\([^ ]+?\\) *: *\\(.*?\\)[[:space:]]*$" bound t)
                  (when (string= "uuid" (match-string-no-properties 1))
                    (setq uuid (match-string-no-properties 2)))
                  (when (string= "type" (match-string-no-properties 1))


### PR DESCRIPTION
When parsing snippets, ignore any trailing whitespace when assigning a
value to the directive.