### PR TITLE
Respect y-b-l-cond from binding triggered snippets

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -462,10 +462,10 @@ Attention: These hooks are not run when exiting nested/stacked snippet expansion
   "Hooks to run just before expanding a snippet.")
 
 (defvar yas-buffer-local-condition
-  '(if (and (or (fourth (syntax-ppss))
-                (fifth (syntax-ppss)))
-	    this-command
-            (eq this-command 'yas-expand-from-trigger-key))
+  '(if (and (let ((ppss (syntax-ppss)))
+              (or (nth 3 ppss) (nth 4 ppss)))
+            (memq this-command '(yas-expand yas-expand-from-trigger-key
+                                            yas-expand-from-keymap)))
        '(require-snippet-condition . force-in-comment)
      t)
   "Snippet expanding condition.


### PR DESCRIPTION
Fixes #305. Though I hesitate to merge this; since the condition was effectively ignored for a long time due to only checking `yas-expand-from-trigger-key` and not `yas-expand`, I wonder if people will start complaining that snippets no longer work in comments...

```
The default value for `yas-buffer-local-condition' was only effective
for `yas-expand-from-trigger-key' command, so it didn't have any effect
when triggering snippets from a key binding (or if using the
`yas-expand' alias).

* yasnippet.el (yas-buffer-local-condition): Check if `this-command' is
  `yas-expand' or `yas-expand-from-keymap' too.
```