### PR TITLE
Only self-insert should clear field

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3385,9 +3385,8 @@ Move the overlay, or create it if it does not exit."
 (defun yas--on-field-overlay-modification (overlay after? _beg _end &optional _length)
   "Clears the field and updates mirrors, conditionally.
 
-Only clears the field if it hasn't been modified and it point it
-at field start.  This hook doesn't do anything if an undo is in
-progress."
+Only clears the field if it hasn't been modified and point is at
+field start.  This hook does nothing if an undo is in progress."
   (unless (or yas--inhibit-overlay-hooks
               (not (overlayp yas--active-field-overlay)) ; Avoid Emacs bug #21824.
               (yas--undo-in-progress))
@@ -3399,7 +3398,8 @@ progress."
                (yas--field-update-display field))
              (yas--update-mirrors snippet))
             (field
-             (when (and (not (yas--field-modified-p field))
+             (when (and (eq this-command 'self-insert-command)
+                        (not (yas--field-modified-p field))
                         (= (point) (yas--field-start field)))
                (yas--skip-and-clear field))
              (setf (yas--field-modified-p field) t))))))


### PR DESCRIPTION
Fixes #515.

```
Only self-insert should clear field

* yasnippet.el (yas--on-field-overlay-modification): Only clear field if
  `this-command' is `self-insert'.
```