### PR TITLE
Decide field clearing commands based on delsel

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -160,20 +160,17 @@
     (ert-simulate-command '(yas-prev-field))
     (should (looking-at "brother"))))
 
-(ert-deftest dont-clear-on-yank-issue-515 ()
-  "A yank shouldn't clear and unmodified field." ; or should it? -- jt
+(ert-deftest do-clear-on-yank-issue-515 ()
+  "A yank should clear an unmodified field."
   (with-temp-buffer
     (yas-minor-mode 1)
     (yas-expand-snippet "my ${1:kid brother} from another ${2:mother}")
-
-    (yas-mock-yank "little")
-    (yas-mock-insert " ")
-
+    (yas-mock-yank "little sibling")
     (should (string= (yas--buffer-contents)
-                     "my little kid brother from another mother"))
+                     "my little sibling from another mother"))
     (ert-simulate-command '(yas-next-field))
     (ert-simulate-command '(yas-prev-field))
-    (should (looking-at "little kid brother"))))
+    (should (looking-at "little sibling"))))
 
 
 ;;; Snippet expansion and character escaping

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3383,7 +3383,14 @@ Move the overlay, or create it if it does not exit."
     (overlay-put yas--active-field-overlay 'insert-behind-hooks
                  '(yas--on-field-overlay-modification))))
 
-(defun yas--on-field-overlay-modification (overlay after? _beg _end &optional _length)
+(defun yas--skip-and-clear-field-p (field _beg _end &optional _length)
+  "Tell if newly modified FIELD should be cleared and skipped.
+BEG, END and LENGTH like overlay modification hooks."
+  (and (eq this-command 'self-insert-command)
+       (not (yas--field-modified-p field))
+       (= (point) (yas--field-start field))))
+
+(defun yas--on-field-overlay-modification (overlay after? beg end &optional length)
   "Clears the field and updates mirrors, conditionally.
 
 Only clears the field if it hasn't been modified and point is at
@@ -3399,9 +3406,7 @@ field start.  This hook does nothing if an undo is in progress."
                (yas--field-update-display field))
              (yas--update-mirrors snippet))
             (field
-             (when (and (eq this-command 'self-insert-command)
-                        (not (yas--field-modified-p field))
-                        (= (point) (yas--field-start field)))
+             (when (yas--skip-and-clear-field-p field beg end)
                (yas--skip-and-clear field))
              (setf (yas--field-modified-p field) t))))))
 

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3386,9 +3386,13 @@ Move the overlay, or create it if it does not exit."
 (defun yas--skip-and-clear-field-p (field _beg _end &optional _length)
   "Tell if newly modified FIELD should be cleared and skipped.
 BEG, END and LENGTH like overlay modification hooks."
-  (and (eq this-command 'self-insert-command)
-       (not (yas--field-modified-p field))
-       (= (point) (yas--field-start field))))
+  (and (not (yas--field-modified-p field))
+       (= (point) (yas--field-start field))
+       (require 'delsel)
+       (let ((clearp (get this-command 'delete-selection)))
+         (when (functionp clearp)
+           (setq clearp (funcall clearp)))
+         clearp)))
 
 (defun yas--on-field-overlay-modification (overlay after? beg end &optional length)
   "Clears the field and updates mirrors, conditionally.

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3389,8 +3389,12 @@ BEG, END and LENGTH like overlay modification hooks."
   (and (not (yas--field-modified-p field))
        (= (point) (yas--field-start field))
        (require 'delsel)
-       (let ((clearp (get this-command 'delete-selection)))
-         (when (functionp clearp)
+       ;; `yank' sets `this-command' to t during execution.
+       (let ((clearp (get (if (commandp this-command) this-command
+                            this-original-command)
+                          'delete-selection)))
+         (when (and (not (memq clearp '(yank supersede kill)))
+                    (functionp clearp))
            (setq clearp (funcall clearp)))
          clearp)))
 


### PR DESCRIPTION
It seems that it's not working for `yank` though, somehow when the overlay modification is triggered `this-command` has been set to `t`. Still need to investigate why.

```
* yasnippet.el (yas--skip-and-clear-field-p): Check `delete-selection'
  of `this-command'.
```