### PR TITLE
add yas-next-field-will-exit-p

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3063,6 +3063,13 @@ Otherwise delegate to `yas-next-field'."
             (yas-next-field))))
     (yas-next-field)))
 
+(defun yas-next-field-will-exit-p (&optional arg)
+  "Return non-nil if (yas-next-field ARG) would exit the current snippet."
+  (let ((snippet (car (yas--snippets-at-point)))
+        (active (overlay-get yas--active-field-overlay 'yas--field)))
+    (when snippet
+      (not (yas--find-next-field arg snippet active)))))
+
 (defun yas--find-next-field (n snippet active)
   "Return the Nth field after the ACTIVE one in SNIPPET."
   (let ((live-fields (cl-remove-if


### PR DESCRIPTION
fixes #561. I will delay merging this until after the release since I changed around the implementation of `yas-next-field` (in a potentially breaking way). EDIT: indeed the tests are indicating breakage.