### PR TITLE
Don't use yas-x-prompt by default

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -213,8 +213,7 @@ If nil, don't use any snippet."
   :type 'string
   :group 'yasnippet)
 
-(defcustom yas-prompt-functions '(yas-x-prompt
-                                  yas-dropdown-prompt
+(defcustom yas-prompt-functions '(yas-dropdown-prompt
                                   yas-completing-prompt
                                   yas-maybe-ido-prompt
                                   yas-no-prompt)


### PR DESCRIPTION
```
It is not a very pleasant method when there are many values, and
`yas-completing-prompt' will usually do a better job, in addition to
respecting customizations to `completing-read-function'.
`yas-dropdown-prompt' remains in first place, since it only takes effect
if the `dropdown' library is loaded, which likely indicates a preference
for it.

* yasnippet.el (yas-prompt-functions): Remove yas-x-prompt from default value.
```

Fixes #655. I intend to merge this *before* the release.