### PR TITLE
Reduce `yas-new-snippet-default'

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -202,10 +202,9 @@ created with `yas-new-snippet'. "
 (defvaralias 'yas/root-directory 'yas-snippet-dirs)
 
 (defcustom yas-new-snippet-default "\
-# -*- mode: snippet; require-final-newline: nil -*-
+# -*- mode: snippet -*-
 # name: $1
-# key: ${2:${1:$(yas--key-from-desc yas-text)}}${3:
-# binding: ${4:direct-keybinding}}
+# key: ${2:${1:$(yas--key-from-desc yas-text)}}
 # --
 $0"
   "Default snippet to use when creating a new snippet.


### PR DESCRIPTION
```
* yasnippet.el (yas-new-snippet-default): Remove
  "require-final-newline: nil", it's redundant since `snippet-mode' already
  sets that.  Also remove the direct-keybinding, since it's hardly ever
  used, and often the literal "# binding: direct-keybinding" ends up in
  actual snippets.
```

One last(?) thing before release.