### PR TITLE
Disable show-trailing-whitespace

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -2672,7 +2672,8 @@ and `kill-buffer' instead."
                  (setq continue (and choose (y-or-n-p "Show also non-active tables? ")))))
              (yas--create-snippet-xrefs)
              (help-mode)
-             (setq-local show-trailing-whitespace nil)
+             (when (boundp 'show-trailing-whitespace)
+               (setq show-trailing-whitespace nil))
              (goto-char 1))
             (t
              (insert "\n\nYASnippet tables by NAMEHASH: \n")

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -2672,6 +2672,7 @@ and `kill-buffer' instead."
                  (setq continue (and choose (y-or-n-p "Show also non-active tables? ")))))
              (yas--create-snippet-xrefs)
              (help-mode)
+             (setq-local show-trailing-whitespace nil)
              (goto-char 1))
             (t
              (insert "\n\nYASnippet tables by NAMEHASH: \n")

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -2660,7 +2660,7 @@ and `kill-buffer' instead."
       (setq buffer-read-only nil)
       (erase-buffer)
       (cond ((not by-name-hash)
-             (insert "YASnippet tables: \n")
+             (insert "YASnippet tables:\n")
              (while (and table-lists
                          continue)
                (dolist (table (car table-lists))
@@ -2718,19 +2718,21 @@ and `kill-buffer' instead."
          (setq group (truncate-string-to-width group 25 0 ?  "..."))
          (insert (make-string 100 ?-) "\n")
          (dolist (p templates)
-           (let ((name (truncate-string-to-width (propertize (format "\\\\snippet `%s'" (yas--template-name p))
-                                                             'yasnippet p)
-                                                 50 0 ? "..."))
-                 (group (prog1 group
-                          (setq group (make-string (length group) ? ))))
-                 (condition-string (let ((condition (yas--template-condition p)))
-                                     (if (and condition
-                                              original-buffer)
-                                         (with-current-buffer original-buffer
-                                           (if (yas--eval-condition condition)
-                                               "(y)"
-                                             "(s)"))
-                                       "(a)"))))
+           (let* ((name (truncate-string-to-width (propertize (format "\\\\snippet `%s'" (yas--template-name p))
+                                                              'yasnippet p)
+                                                  50 0 ? "..."))
+                  (group (prog1 group
+                           (setq group (make-string (length group) ? ))))
+                  (condition-string (let ((condition (yas--template-condition p)))
+                                      (if (and condition
+                                               original-buffer)
+                                          (with-current-buffer original-buffer
+                                            (if (yas--eval-condition condition)
+                                                "(y)"
+                                              "(s)"))
+                                        "(a)")))
+                  (key-description-string (key-description (yas--template-keybinding p)))
+                  (template-key-padding (if (string= key-description-string "") nil ? )))
              (insert group " ")
              (insert condition-string " ")
              (insert name
@@ -2739,9 +2741,10 @@ and `kill-buffer' instead."
                        " ")
                      " ")
              (insert (truncate-string-to-width (or (yas--template-key p) "")
-                                               15 0 ?  "...") " ")
-             (insert (truncate-string-to-width (key-description (yas--template-keybinding p))
-                                               15 0 ?  "...") " ")
+                                               15 0 template-key-padding "...")
+                     (if template-key-padding (byte-to-string template-key-padding) ""))
+             (insert (truncate-string-to-width key-description-string
+                                               15 0 nil "..."))
              (insert "\n"))))
      groups-hash)))
 


### PR DESCRIPTION
Hi,

I'm using `(setq-default show-trailing-whitespace t)`.

![2016-03-29 9 37 02](https://cloud.githubusercontent.com/assets/822086/14108186/2a047dfc-f5f7-11e5-83e0-9b05e823136d.png)

see [GNU Emacs Manual: Useless Whitespace](http://www.gnu.org/software/emacs/manual/html_node/emacs/Useless-Whitespace.html)
