### PR TITLE
use delete-region instead of kill-region in yas--create-snippet-xrefs

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -4374,8 +4374,8 @@ object satisfying `yas--field-p' to restrict the expansion to.")))
                                          'yasnippet)))
         (when template
           (help-xref-button 1 'help-snippet-def template)
-          (kill-region (match-end 1) (match-end 0))
-          (kill-region (match-beginning 0) (match-beginning 1)))))))
+          (delete-region (match-end 1) (match-end 0))
+          (delete-region (match-beginning 0) (match-beginning 1)))))))
 
 ;;; Utils
 


### PR DESCRIPTION
i ran into issue #550, and found that for me it was a `pbcopy.el` interaction issue. `pbcopy.el` doesn't seem to like the the many calls to kill-region in `yas--create-snippet-xrefs`. since we don't want a bunch of `\\snippet`s in our kill-ring anyways, we should use `delete-region` instead.
