### PR TITLE
Avoid potential problems with user's hooks

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -880,7 +880,7 @@ Honour `yas-dont-activate', which see."
 (defvar yas--font-lock-keywords
   (append '(("^#.*$" . font-lock-comment-face))
           (with-temp-buffer
-            (emacs-lisp-mode)
+            (ignore-errors (emacs-lisp-mode))
             (font-lock-set-defaults)
             (if (eq t (car-safe font-lock-keywords))
                 ;; They're "compiled", so extract the source.

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -913,6 +913,7 @@ Honour `yas-dont-activate', which see."
   "The keymap used when `snippet-mode' is active.")
 
 
+;;;###autoload
 (define-derived-mode snippet-mode text-mode "Snippet"
   "A mode for editing yasnippets"
   (setq font-lock-defaults '(yas--font-lock-keywords))


### PR DESCRIPTION
```
* yasnippet.el (yas--font-lock-keywords): ignore-errors from
emacs-lisp-mode call, in case user's hooks cause problems (e.g. enabling
`yas-minor-mode' before we finish loading).
```

fix #673, replace/ close #674.