### PR TITLE
Don't kill snippets for text property modification

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3471,7 +3471,7 @@ Move the overlays, or create them if they do not exit."
   "Commit the snippet if the protection overlay is being killed."
   (unless (or yas--inhibit-overlay-hooks
               (not after?)
-              (/= length (- end beg)) ; deletion or insertion
+              (= length (- end beg)) ; deletion or insertion
               (yas--undo-in-progress))
     (let ((snippets (yas--snippets-at-point)))
       (yas--message 3 "Comitting snippets. Action would destroy a protection overlay.")

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3467,23 +3467,16 @@ Move the overlays, or create them if they do not exit."
              ;; (overlay-put ov 'evaporate t)
              (overlay-put ov 'modification-hooks '(yas--on-protection-overlay-modification)))))))
 
-(defvar yas--buffer-pre-modification)
-
-(defun yas--on-protection-overlay-modification (_overlay after? beg end &optional _length)
-  "Signals a snippet violation, then issues error.
-
-The error should be ignored in `debug-ignored-errors'"
+(defun yas--on-protection-overlay-modification (_overlay after? beg end &optional length)
+  "Commit the snippet if the protection overlay is being killed."
   (unless (or yas--inhibit-overlay-hooks
+              (not after?)
+              (/= length (- end beg)) ; deletion or insertion
               (yas--undo-in-progress))
-    (if after?
-        (unless (string= yas--buffer-pre-modification
-                         (buffer-substring-no-properties beg end))
-         (let ((snippets (yas--snippets-at-point)))
-           (yas--message 3 "Comitting snippets. Action would destroy a protection overlay.")
-           (cl-loop for snippet in snippets
-                    do (yas--commit-snippet snippet))))
-      (setq-local yas--buffer-pre-modification
-                  (buffer-substring-no-properties beg end)))))
+    (let ((snippets (yas--snippets-at-point)))
+      (yas--message 3 "Comitting snippets. Action would destroy a protection overlay.")
+      (cl-loop for snippet in snippets
+               do (yas--commit-snippet snippet)))))
 
 (add-to-list 'debug-ignored-errors "^Exit the snippet first!$")
 


### PR DESCRIPTION
Fixes #677, I think also fixes #666.

```
cc-mode modifies text properties in the buffer do cache parsing results,
therefore it's important that yasnippet not kill yasnippets when parsing
is triggered by function that only wants to parse the
buffer (e.g. which-function-mode).

* yasnippet.el (yas--buffer-pre-modification): New variable.
(yas--on-protection-overlay-modification): Save buffer text (without
properties) on the before change call, and compare on the after change
call.
```