### PR TITLE
Decide field clearing based on command's effect

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3395,9 +3395,9 @@ Move the overlay, or create it if it does not exit."
 (defun yas--skip-and-clear-field-p (field beg _end length)
   "Tell if newly modified FIELD should be cleared and skipped.
 BEG, END and LENGTH like overlay modification hooks."
-  (and (not (yas--field-modified-p field))
-       (= beg (yas--field-start field))
-       (= length 0))) ; A 0 pre-change length indicates insertion.
+  (and (= length 0) ; A 0 pre-change length indicates insertion.
+       (= beg (yas--field-start field)) ; Insertion at field start?
+       (not (yas--field-modified-p field))))
 
 (defun yas--on-field-overlay-modification (overlay after? beg end &optional length)
   "Clears the field and updates mirrors, conditionally.
@@ -3412,6 +3412,7 @@ field start.  This hook does nothing if an undo is in progress."
            (field (overlay-get overlay 'yas--field))
            (snippet (overlay-get yas--active-field-overlay 'yas--snippet)))
       (when (yas--skip-and-clear-field-p field beg end length)
+        ;; We delete text starting from the END of insertion.
         (yas--skip-and-clear field end))
       (setf (yas--field-modified-p field) t)
       (yas--advance-end-maybe field (overlay-end overlay))


### PR DESCRIPTION
Fixes #662.
```
In [1] we started deciding clearing based on a command's
delete-selection property, but it turns out that some commands perform
insertion, and optionally use the region's contents.  So these commands
should have a nil delete-selection property, but they still ought to
clear a snippet field when used.

To achieve this, we now check if the command has inserted text in the
post-change hook of the field overlay.

* yasnippet.el (yas--skip-and-clear): Add optional FROM paramter.  Only
clear non-empty fields.
(yas--skip-and-clear-field-p): Check the pre-change point and length
instead of current command delete-selection property.
(yas--on-field-overlay-modification): Perform field clearing on the
post-change call.

[1]: acf2cdd "Decide field clearing commands based on delsel"
```