### PR TITLE
Fix some issues with yas-wrap-around-region

### DIFF
--- a/doc/snippet-expansion.org
+++ b/doc/snippet-expansion.org
@@ -83,6 +83,19 @@ snippets for the major mode, prefix this command with =C-u=.
 The prompting methods used are again controlled by
 [[sym:yas-prompt-functions][=yas-prompt-functions=]].
 
+*** Inserting region or register contents into snippet
+
+It's often useful to inject already written text in the middle of a
+snippet.  The variable [[sym:yas-wrap-around-region][=yas-wrap-around-region=]] when to t substitute
+the region contents into the =$0= placeholder of a snippet expanded by
+[[#yas-insert-snippet][=yas-insert-snippet=]].  Setting it to a character value (e.g. =?0=)
+will insert the contents of corresponding register.
+
+Older (versions 0.9.1 and below) of Yasnippet, supported a setting of
+=cua= that is equivalent to =?0= but only worked with =cua-mode=
+turned on.  This setting is still supported for backwards
+compatibility, but is now entirely equivalent to =?0=.
+
 ** Snippet keybinding
 
 See the section of the =# binding:= directive in

--- a/doc/snippet-expansion.org
+++ b/doc/snippet-expansion.org
@@ -29,7 +29,7 @@
 
    - Expanding from emacs-lisp code
 
-** Trigger key
+** <<Trigger key>>
 
 [[sym:yas-expand][=yas-expand=]] tries to expand a /snippet abbrev/ (also known as
 /snippet key/) before point.
@@ -90,6 +90,10 @@ snippet.  The variable [[sym:yas-wrap-around-region][=yas-wrap-around-region=]] 
 the region contents into the =$0= placeholder of a snippet expanded by
 [[#yas-insert-snippet][=yas-insert-snippet=]].  Setting it to a character value (e.g. =?0=)
 will insert the contents of corresponding register.
+
+Note a setting of t is disabled when expanding via [[trigger key]] since
+it's too awkward to highlight the relevant text while maneuvering
+point in front of the trigger key.
 
 Older (versions 0.9.1 and below) of Yasnippet, supported a setting of
 =cua= that is equivalent to =?0= but only worked with =cua-mode=

--- a/doc/snippet-expansion.org
+++ b/doc/snippet-expansion.org
@@ -29,7 +29,7 @@
 
    - Expanding from emacs-lisp code
 
-** <<Trigger key>>
+** Trigger key
 
 [[sym:yas-expand][=yas-expand=]] tries to expand a /snippet abbrev/ (also known as
 /snippet key/) before point.
@@ -90,10 +90,6 @@ snippet.  The variable [[sym:yas-wrap-around-region][=yas-wrap-around-region=]] 
 the region contents into the =$0= placeholder of a snippet expanded by
 [[#yas-insert-snippet][=yas-insert-snippet=]].  Setting it to a character value (e.g. =?0=)
 will insert the contents of corresponding register.
-
-Note a setting of t is disabled when expanding via [[trigger key]] since
-it's too awkward to highlight the relevant text while maneuvering
-point in front of the trigger key.
 
 Older (versions 0.9.1 and below) of Yasnippet, supported a setting of
 =cua= that is equivalent to =?0= but only worked with =cua-mode=

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -2160,7 +2160,12 @@ Optional argument FIELD is for non-interactive use and is an
 object satisfying `yas--field-p' to restrict the expansion to."
   (interactive)
   (setq yas--condition-cache-timestamp (current-time))
-  (let (templates-and-pos)
+  (let ((templates-and-pos nil)
+        ;; Disable region wrapping for trigger key expansion: it's too
+        ;; awkward to have point after the trigger while managing the
+        ;; region contents anyway.
+        (yas-wrap-around-region (if (eq yas-wrap-around-region t) nil
+                                  yas-wrap-around-region)))
     (unless (and yas-expand-only-for-last-commands
                  (not (member last-command yas-expand-only-for-last-commands)))
       (setq templates-and-pos (if field

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -349,7 +349,9 @@ Any other non-nil value, every submenu is listed."
   "What to insert for snippet's $0 field.
 
 If set to a character, insert contents of corresponding register.
-If non-nil insert region contents."
+If non-nil insert region contents.  This can be overridden on a
+per-snippet basis.  A value of `cua' is considered equivalent to
+`?0' for backwards compatibility."
   :type '(choice (character :tag "Insert from register")
                  (const t :tag "Insert region contents")
                  (const nil :tag "Don't insert anything")

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -2170,9 +2170,13 @@ object satisfying `yas--field-p' to restrict the expansion to."
                                     (yas--templates-for-key-at-point))
                                 (yas--templates-for-key-at-point))))
     (if templates-and-pos
-        (yas--expand-or-prompt-for-template (nth 0 templates-and-pos)
-                                            (nth 1 templates-and-pos)
-                                            (nth 2 templates-and-pos))
+        (yas--expand-or-prompt-for-template
+         (nth 0 templates-and-pos)
+         ;; Delete snippet key and active region when expanding.
+         (min (if (use-region-p) (region-beginning) most-positive-fixnum)
+              (nth 1 templates-and-pos))
+         (max (if (use-region-p) (region-end) most-negative-fixnum)
+              (nth 2 templates-and-pos)))
       (yas--fallback))))
 
 (defun yas-expand-from-keymap ()

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -2160,12 +2160,7 @@ Optional argument FIELD is for non-interactive use and is an
 object satisfying `yas--field-p' to restrict the expansion to."
   (interactive)
   (setq yas--condition-cache-timestamp (current-time))
-  (let ((templates-and-pos nil)
-        ;; Disable region wrapping for trigger key expansion: it's too
-        ;; awkward to have point after the trigger while managing the
-        ;; region contents anyway.
-        (yas-wrap-around-region (if (eq yas-wrap-around-region t) nil
-                                  yas-wrap-around-region)))
+  (let (templates-and-pos)
     (unless (and yas-expand-only-for-last-commands
                  (not (member last-command yas-expand-only-for-last-commands)))
       (setq templates-and-pos (if field


### PR DESCRIPTION
This PR collects a few fixes/improvements to the `yas-wrap-around-region` feature.

- fixes #374.
- fixes #523.
- fixes #636.