### PR TITLE
Don't indent empty lines in snippet expansion

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -200,9 +200,13 @@
     (set (make-local-variable 'yas-indent-line) 'auto)
     (set (make-local-variable 'yas-also-auto-indent-first-line) t)
     (yas-expand-snippet "def ${1:method}${2:(${3:args})}\n$0\nend")
+    ;; Note that empty line is not indented.
+    (should (string= "def method(args)
+
+end" (buffer-string)))
     (cl-loop repeat 3 do (ert-simulate-command '(yas-next-field)))
     (yas-mock-insert (make-string (random 5) ?\ )) ; purposedly mess up indentation
-    (yas-expand-snippet "class << ${self}\n$0\nend")
+    (yas-expand-snippet "class << ${self}\n  $0\nend")
     (ert-simulate-command '(yas-next-field))
     (should (string= "def method(args)
   class << self

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3918,7 +3918,8 @@ The SNIPPET's markers are preserved."
       (goto-char from)
       (save-restriction
         (widen)
-        (cl-loop do
+        ;; Indent each non-empty line.
+        (cl-loop if (/= (line-beginning-position) (line-end-position)) do
                  (back-to-indentation)
                  (let ((trouble-markers ; The markers at (point).
                         (cl-remove (point) snippet-markers :test #'/=)))


### PR DESCRIPTION
fixes #679.
```
* yasnippet.el (yas--indent-region): Indent only non-empty lines.
* yasnippet-tests.el (basic-indentation): Add empy and non-empty (but
blank) lines in test snippet.
```