### PR TITLE
Document $> and fix escaping

### DIFF
--- a/doc/snippet-development.org
+++ b/doc/snippet-development.org
@@ -422,3 +422,9 @@ the exit marker.
 By the way, =C-d= will only clear the field if you cursor is at the
 beginning of the field /and/ it hasn't been changed yet. Otherwise, it
 performs the normal Emacs =delete-char= command.
+
+** Indentation markers
+
+If [[sym:yas-indent-line][=yas-indent-line=]] is *not* set to '=auto=, it's still possible to
+indent specific lines by adding an indentation marker, =$>=, somewhere
+on the line.

--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -211,6 +211,19 @@
 end" (buffer-string)))
     (should (= 4 (current-column)))))
 
+(ert-deftest indentation-markers ()
+  "Test a snippet with indentation markers (`$<')."
+  (with-temp-buffer
+    (ruby-mode)
+    (yas-minor-mode 1)
+    (set (make-local-variable 'yas-indent-line) nil)
+    (yas-expand-snippet "def ${1:method}${2:(${3:args})}\n$>Indent\nNo indent\\$>\nend")
+    (should (string= "def method(args)
+  Indent
+No indent$>
+end" (buffer-string)))))
+
+
 (ert-deftest navigate-a-snippet-with-multiline-mirrors-issue-665 ()
   "In issue 665, a multi-line mirror is attempted.
 

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -3826,6 +3826,9 @@ cons cells to this var.")
 backquoted Lisp expressions should be inserted at the end of
 expansion.")
 
+(defvar yas--indent-markers nil
+  "List of markers for manual indentation.")
+
 (defun yas--snippet-parse-create (snippet)
   "Parse a recently inserted snippet template, creating all
 necessary fields, mirrors and exit points.
@@ -3845,6 +3848,9 @@ Meant to be called in a narrowed buffer, does various passes"
     ;; protect escaped characters
     ;;
     (yas--protect-escapes)
+    ;; Parse indent markers: `$>'.
+    (goto-char parse-start)
+    (yas--indent-parse-create snippet)
     ;; parse fields with {}
     ;;
     (goto-char parse-start)
@@ -3931,14 +3937,17 @@ The SNIPPET's markers are preserved."
 
 (defvar yas--indent-original-column nil)
 (defun yas--indent (snippet)
-  ;; Look for those `$>'.
+  ;; Indent lines that had indent markers (`$>') on them.
   (save-excursion
-    (while (re-search-forward "$>" nil t)
-      (delete-region (match-beginning 0) (match-end 0))
+    (dolist (marker yas--indent-markers)
       (unless (eq yas-indent-line 'auto)
+        (goto-char marker)
         (yas--indent-region (line-beginning-position)
                             (line-end-position)
-                            snippet))))
+                            snippet))
+      ;; Finished with this marker.
+      (set-marker marker nil))
+    (setq yas--indent-markers nil))
   ;; Now do stuff for `fixed' and `auto'.
   (save-excursion
     (cond ((eq yas-indent-line 'fixed)
@@ -4043,6 +4052,16 @@ with their evaluated value into `yas--backquote-markers-and-strings'."
   (let ((marker (set-marker (make-marker) pos)))
     (set-marker-insertion-type marker nil)
     marker))
+
+(defun yas--indent-parse-create (snippet)
+  "Parse the \"$>\" indentation markers in SNIPPET."
+  (setq yas--indent-markers ())
+  (while (search-forward "$>" nil t)
+    (delete-region (match-beginning 0) (match-end 0))
+    ;; Mark the beginning of the line.
+    (push (yas--make-marker (line-beginning-position))
+          yas--indent-markers))
+  (setq yas--indent-markers (nreverse yas--indent-markers)))
 
 (defun yas--field-parse-create (snippet &optional parent-field)
   "Parse most field expressions in SNIPPET, except for the simple one \"$n\".


### PR DESCRIPTION
fix #640.
```
* doc/snippet-development.org: New "Indentation markers" section.
* yasnippet-tests.el (indentation-markers): New test.
* yasnippet.el (yas--indent-markers): New variable.
(yas--indent): Use it instead of searching for $> directly.
(yas--indent-parse-create): New function, records occurences of $> into
`yas--indent-markers'.
(yas--snippet-parse-create): Call it.
```