### PR TITLE
Add yas-backport-obsolete-alias option

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -386,6 +386,11 @@ the trigger key itself."
   :type '(repeat function)
   :group 'yasnippet)
 
+(defcustom yas-backport-obsolete-alias t
+  "If non-nil backport function and variables from old version of yasnippet."
+  :type 'boolean
+  :group 'yasnippet)
+
 ;; Only two faces, and one of them shouldn't even be used...
 ;;
 (defface yas-field-highlight-face
@@ -4598,14 +4603,15 @@ and return the directory.  Return nil if not found."
 
 They are mapped to \"yas/*\" variants.")
 
-(dolist (sym yas--backported-syms)
-  (let ((backported (intern (replace-regexp-in-string "\\`yas-" "yas/" (symbol-name sym)))))
-    (when (boundp sym)
-      (make-obsolete-variable backported sym "yasnippet 0.8")
-      (defvaralias backported sym))
-    (when (fboundp sym)
-      (make-obsolete backported sym "yasnippet 0.8")
-      (defalias backported sym))))
+(when yas-backport-obsolete-alias
+  (dolist (sym yas--backported-syms)
+    (let ((backported (intern (replace-regexp-in-string "\\`yas-" "yas/" (symbol-name sym)))))
+      (when (boundp sym)
+        (make-obsolete-variable backported sym "yasnippet 0.8")
+        (defvaralias backported sym))
+      (when (fboundp sym)
+        (make-obsolete backported sym "yasnippet 0.8")
+        (defalias backported sym)))))
 
 (defvar yas--exported-syms
   (let (exported)


### PR DESCRIPTION
## Problem

Many functions and variables have both prefix `yas-` and `yas/`.  This is useful for users who want to update from the old version, but it is unnecessary feature for users of the latest version.

I am using `helm-M-x`.

![2016-05-15 1 27 52](https://cloud.githubusercontent.com/assets/822086/15269535/aa12d9f8-1a3c-11e6-9934-b91992f53f61.png)

## Proposal

Add `yas-backport-obsolete-alias` custom variable.  Don't make alias If this variable is `nil`.

I am not good at English, I think there is a better variable name.