### PR TITLE
Add yas-snippet-trim feature

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -1768,6 +1768,20 @@ add the snippets associated with the given mode."
        (yas-should-not-expand '("_"))
        (yas-should-expand '(("car" . "(car )")))))))
 
+(ert-deftest simple-trim ()
+  (let ((yas-snippet-trim t))
+    (with-temp-buffer
+      (yas-minor-mode 1)
+      (yas-expand-snippet "
+${1:brother} from another $1
+
+")
+      (should (string= (yas--buffer-contents)
+                       "brother from another brother"))
+      (yas-mock-insert "bla")
+      (should (string= (yas--buffer-contents)
+                       "bla from another bla")))))
+
 
 
 (provide 'yasnippet-tests)


### PR DESCRIPTION
Hi!
First, thanks for such a awesome package!

I add `snippet-trim` feature and add its optional variable named
`yas-snippet-trim`.

This feature is disabled at default, but if the user enable,
`string-trim` snippet before expand snippet.

This is a great solution for #767, #365, #192.
And this issue is also written in [FAQ](https://github.com/joaotavora/yasnippet/blob/e45e3de357fbd4289fcfa3dd26aaa7be357fb0b8/doc/faq.org#why-is-there-an-extra-newline)