### PR TITLE
Prevent yas-new-snippet inserting region twice

### DIFF
--- a/yasnippet.el
+++ b/yasnippet.el
@@ -2682,7 +2682,7 @@ NO-TEMPLATE is non-nil."
     (set (make-local-variable 'default-directory)
          (car (cdr (car guessed-directories))))
     (if (and (not no-template) yas-new-snippet-default)
-        (yas-expand-snippet yas-new-snippet-default))))
+        (yas-expand-snippet yas-new-snippet-default nil nil '((yas-wrap-around-region nil))))))
 
 (defun yas--compute-major-mode-and-parents (file)
   "Given FILE, find the nearest snippet directory for a given mode.


### PR DESCRIPTION
On yas-new-snippet, if yas-wrap-around-region is t and
yas-new-snippet-default has its default value, the selected region is
inserted twice: Once for yas-selected-text and once for $0.

The yas-new-snippet-default snippet is a special usage scenario, where
values of yas-wrap-around-region other than nil don't make much sense,
so override it.