### PR TITLE
Preserve post-command setup after quitting a prompt

### DIFF
--- a/yasnippet-tests.el
+++ b/yasnippet-tests.el
@@ -674,6 +674,30 @@ mapconcat #'(lambda (arg)
   (declare (debug t))
   `(yas-call-with-saving-variables #'(lambda () ,@body)))
 
+(ert-deftest post-command-handler-keeps-mode-setup-after-quit ()
+  "Keep YASnippet setup intact when an exit-transform prompt is quit."
+  (yas-saving-variables
+   (yas-with-snippet-dirs
+       '((".emacs.d/snippets"
+          ("fundamental-mode"
+           ("wi" . "${1:field}${0:$$(yas-choose-value \"one\" \"two\")}")
+           ("ok" . "expanded"))))
+     (yas-reload-all)
+     (with-temp-buffer
+       (let ((yas-prompt-functions '(yas-completing-prompt)))
+         (yas-minor-mode 1)
+         (insert "wi")
+         (ert-simulate-command '(yas-expand))
+         (cl-letf (((symbol-function 'completing-read)
+                    (lambda (&rest _) (signal 'minibuffer-quit nil))))
+           (ert-simulate-command '(yas-next-field))))
+       (should yas-minor-mode)
+       (should (memq #'yas--post-command-handler post-command-hook))
+       (erase-buffer)
+       (insert "ok")
+       (ert-simulate-command '(yas-expand))
+       (should (equal (buffer-string) "expanded"))))))
+
 (ert-deftest auto-next-field ()
   "Automatically exit a field after evaluating its transform."
   (with-temp-buffer

--- a/yasnippet.el
+++ b/yasnippet.el
@@ -4962,9 +4962,9 @@ When multiple expressions are found, only the last one counts."
 ;;
 (defun yas--post-command-handler ()
   "Handles various yasnippet conditions after each command."
-  (yas--do-todo-snippet-indent)
   (condition-case err
-      (progn (yas--finish-moving-snippets)
+      (progn (yas--do-todo-snippet-indent)
+             (yas--finish-moving-snippets)
              (cond ((eq 'undo this-command)
                     ;;
                     ;; After undo revival the correct field is sometimes not
@@ -4985,6 +4985,7 @@ When multiple expressions are found, only the last one counts."
                     ;; When not in an undo, check if we must commit the snippet
                     ;; (user exited it).
                     (yas--check-commit-snippet))))
+    (quit (message "%s" (error-message-string err)))
     ;; FIXME: Why?
     ((debug error) (signal (car err) (cdr err)))))
 


### PR DESCRIPTION
## Summary

Quitting a prompt from a snippet exit transform lets `minibuffer-quit` escape from `yas--post-command-handler`. Emacs then removes the handler from the buffer-local `post-command-hook`, while leaving `yas-minor-mode` enabled. Later snippet expansions fail with:

```
[yas] ‘yas-expand-snippet’ needs properly setup ‘yas-minor-mode’
```

This change treats `quit` as normal prompt cancellation at the handler boundary. The handler remains installed, while ordinary errors are still re-signaled. It also adds a regression test.

## Reproduction

Define this snippet:

```snippet
# key: test
# --
${1:field}${0:$$(yas-choose-value "one" "two")}
```

Then:

1. Start Emacs with `emacs -Q -nw -L .` and enable `yas-minor-mode`.
2. Expand `test`.
3. Press `TAB` to move from field 1 to the exit field.
4. Press `C-g` at the prompt.
5. Try to expand another snippet.

On `master`, Emacs reports `Error in post-command-hook (yas--post-command-handler): (minibuffer-quit)`, removes the handler, and the next expansion fails. With this change, quitting the prompt leaves YASnippet properly set up and the next snippet expands normally.